### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Declare files that will always have LF line endings on checkout.
+docker-healthcheck text eol=lf
 *.sh text eol=lf
 setup/*.sh linguist-language=Dockerfile
 Makefile linguist-vendored


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This is for Windows Docker Desktop users: bash scripts would be converted into Windows text (CRLF) cause unhealthy containers.

Does this close any currently open issues?
------------------------------------------
Yes. Container unhealthy issue #26.

Any relevant logs, error output, etc?
-------------------------------------
Refer to the issue #26

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
In my Windows 10.
