### PR TITLE
Match spelling that’s in the docs

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ LOGSTASH_PORT=8080
 # This is used to set the password at setup, and used by others to connect to Elasticsearch at runtime.
 # USERNAME cannot be changed! It is set here for parmeterization only.
 ELASTIC_USERNAME=elastic
-ELASTIC_PASSWORD=changme
+ELASTIC_PASSWORD=changeme
 AWS_ACCESS_KEY_ID=nottherealid
 AWS_SECRET_ACCESS_KEY=notherealsecret
 


### PR DESCRIPTION
This looks like an accidental typo. In the docs it only ever refers to “changeme”. The first “e” is missing here.

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
…
