### PR TITLE
make prune only removes this project's volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ logs:			## Tail all logs with -n 1000.
 images:			## Show all Images of ELK and all its extra components.
 	@docker-compose $(COMPOSE_ALL_FILES) images ${ELK_ALL_SERVICES}
 
-prune:			## Remove ELK Containers and Delete Volume Data
+prune:			## Remove ELK Containers and Delete ELK-related Volume Data (the elastic_elasticsearch-data volume)
 	@make stop && make rm
-	@docker volume prune -f
+	@docker volume prune -f --filter label=com.docker.compose.project=elastic
 
 help:       	## Show this help.
 	@echo "Make Application Docker Images and Containers using Docker-Compose files in 'docker' Dir."


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adjust the Makefile and let `make prune` only deletes the volumes created by this docker-compose project. The following command works:

```
docker volume prune -f --filter label=com.docker.compose.project=elastic
```

Does this close any currently open issues?
------------------------------------------
Yes, this closes #72 .

Any relevant logs, error output, etc?
-------------------------------------
Not necessary in this case.

Where has this been tested?
---------------------------
In my local environment.
