### PR TITLE
Warning on ELK version change and volume data index mismatch between Lucene and volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ make keystore
 
 - Makefile is a wrapper around `Docker-Compose` commands, use `make help` to know every command.
 
-- Elasticsearch will save its data to a volume named `elasticsearch-data`
+- Elasticsearch will save its data to a volume named `elasticsearch-data`. ⚠️ You may encounter Lucene mismatch issues (visible on elasticsearch docker logs) on indexing the data on volume during downgrade/upgrade during setup, you may want to delete indexed volumes as the volume is not pointing to a folder!
 
 - Elasticsearch Keystore (that contains passwords and credentials) and SSL Certificate are generated in the `./secrets` directory by the setup command.
 


### PR DESCRIPTION
Update readme for elasticsearch volume warning during version change in .env ELK_VERSION

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Spent too much time experimenting, I've realised that errors caused by ELK version change. When user runs ELK, volume for elastic becomes already created with 8.8.0. Then when you try to switch <8.6.0, required Lucene version for indexing becomes different.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
java.lang.IllegalArgumentException: Could not load codec 'Lucene95'. Did you forget to add lucene-backward-codecs.jar?

Any other comments?
-------------------
It's not confusing, however volume attached to docker is not on local, so it took time for me to realise that. I'm newbie to ELK, so I didn't know Lucene, indexing, elastic stores in docker volume not on local etc.

Where has this been tested?
---------------------------
Ubuntu 20.04, on a typical Amazon EC2 server
