### PR TITLE
Fix syntax error in elasticsearch healthcheck script

### DIFF
--- a/elasticsearch/scripts/docker-healthcheck
+++ b/elasticsearch/scripts/docker-healthcheck
@@ -3,7 +3,7 @@ set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
 
-if health="$(curl -fsSL "https://$ELASTIC_USERNAME:$ELASTIC_PASSWORD@$host:$ELASTICSEARCH_PORT/_cat/health?h=status" --insecure")"; then
+if health="$(curl -fsSL "https://$ELASTIC_USERNAME:$ELASTIC_PASSWORD@$host:$ELASTICSEARCH_PORT/_cat/health?h=status" --insecure)"; then
 	health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green ")
 	if [ "$health" = 'green' ] || [ "$health" = "yellow" ]; then
 		exit 0


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
There is a syntax error (an unbalanced double quote mark) in the healthcheck script for the elasticsearch image.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
locally
