### PR TITLE
Allow changing the APM server port via .env file

### DIFF
--- a/apm-server/config/apm-server.yml
+++ b/apm-server/config/apm-server.yml
@@ -4,7 +4,7 @@
 
 apm-server:
   # Defines the host and port the server is listening on. Use "unix:/path/to.sock" to listen on a unix domain socket.
-  host: "0.0.0.0:8200"
+  host: "0.0.0.0:${APMSERVER_PORT}"
 
 
   #---------------------------- APM Server - Secure Communication with Agents ----------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,8 +134,6 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     restart: unless-stopped
-    ports:
-      - "8200:8200"
     volumes:
       - ./apm-server/config/apm-server.yml:/usr/share/apm-server/apm-server.yml:ro
     environment:
@@ -143,6 +141,9 @@ services:
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
       ELASTICSEARCH_HOST_PORT: https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}
       ELASTIC_APM_SECRET_TOKEN: ${ELASTIC_APM_SECRET_TOKEN}
+      APMSERVER_PORT: ${APMSERVER_PORT}
+    ports:
+      - "${APMSERVER_PORT}:${APMSERVER_PORT}"
     secrets:
       - source: elastic.ca
         target: /certs/ca.crt


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR uses the existing `APMSERVER_PORT` var defined in `.env` file to set the port of the APM server exposed by docker compose and the port used by the APM service running in the `apm-server` container.

Does this close any currently open issues?
------------------------------------------
Don't think so.


Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
no

Where has this been tested?
---------------------------
locally
