### PR TITLE
Use project name from .env for prune make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL:=help
 
+include .env
+
 COMPOSE_ALL_FILES := -f docker-compose.yml -f docker-compose.monitor.yml -f docker-compose.nodes.yml -f docker-compose.logs.yml
 COMPOSE_MONITORING := -f docker-compose.yml -f docker-compose.monitor.yml
 COMPOSE_LOGGING := -f docker-compose.yml -f docker-compose.logs.yml
@@ -75,7 +77,7 @@ images:			## Show all Images of ELK and all its extra components.
 
 prune:			## Remove ELK Containers and Delete ELK-related Volume Data (the elastic_elasticsearch-data volume)
 	@make stop && make rm
-	@docker volume prune -f --filter label=com.docker.compose.project=elastic
+	@docker volume prune -f --filter label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}
 
 help:       	## Show this help.
 	@echo "Make Application Docker Images and Containers using Docker-Compose files in 'docker' Dir."


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The project name can be changed in the `.env` file, but the `make` target `prune` uses a hardcoded value as project name. This change fixes the `Makefile` to use the project name from the `.env` file.

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
no

Where has this been tested?
---------------------------
locally
