### PR TITLE
Add a setup script and according makefile target to upgrade ES keystore from older versions of ES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ endif
 keystore:		## Setup Elasticsearch Keystore, by initializing passwords, and add credentials defined in `keystore.sh`.
 	$(DOCKER_COMPOSE_COMMAND) -f docker-compose.setup.yml run --rm keystore
 
+upgrade-keystore:	## Upgrade Elasticsearch Keystore, which is necessary when upgrading to an Elasticsearch version that uses a newer Java version.
+	@if [ -n "$$($(DOCKER_COMPOSE_COMMAND) ps -q)" ]; then \
+		echo "Please stop all running containers before upgrading the keystore."; \
+		exit 1; \
+	fi
+	$(DOCKER_COMPOSE_COMMAND) -f docker-compose.setup.yml run --rm upgrade-keystore
+
 certs:		    ## Generate Elasticsearch SSL Certs.
 	$(DOCKER_COMPOSE_COMMAND) -f docker-compose.setup.yml run --rm certs
 

--- a/docker-compose.setup.yml
+++ b/docker-compose.setup.yml
@@ -15,6 +15,11 @@ services:
     environment:
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
 
+  upgrade-keystore:
+    extends:
+      service: keystore
+    command: bash /setup/upgrade-keystore.sh
+
   certs:
     image: elastdocker/elasticsearch:${ELK_VERSION}
     build:

--- a/setup/upgrade-keystore.sh
+++ b/setup/upgrade-keystore.sh
@@ -1,0 +1,25 @@
+# Exit on Error
+set -e
+
+KEYSTORE_TO_UPGRADE=/secrets/keystore/elasticsearch.keystore
+KEYSTORE_TO_UPGRADE_BACKUP=$KEYSTORE_TO_UPGRADE.pre-upgrade
+KEYSTORE_LOCATION_FOR_TOOL=/usr/share/elasticsearch/config/elasticsearch.keystore
+
+if [ -f $KEYSTORE_TO_UPGRADE_BACKUP ]; then
+    echo "A backup of a previous run of this script was found at $KEYSTORE_TO_UPGRADE_BACKUP. Aborting execution!"
+    echo "Please remove the backup file and run the script again if you're sure that you want to run the upgrade script again."
+    exit 1
+fi
+
+echo "=========== Upgrading Elasticsearch Keystore =========="
+
+cp $KEYSTORE_TO_UPGRADE $KEYSTORE_LOCATION_FOR_TOOL
+
+echo "Running elasticsearch-keystore upgrade"
+elasticsearch-keystore upgrade
+
+mv $KEYSTORE_TO_UPGRADE $KEYSTORE_TO_UPGRADE_BACKUP
+mv $KEYSTORE_LOCATION_FOR_TOOL $KEYSTORE_TO_UPGRADE
+
+echo "======= Keystore upgrade completed successfully ======="
+echo "Old keystore was backed up to $KEYSTORE_TO_UPGRADE_BACKUP"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When upgrading the stack from ES 8.13.x (and older) to newer versions of Elasticsearch, the generated keystore becomes incompatible. ES then tries to migrate the keystore automatically, but in the container the keystore is mounted via the secrets system and can't be moved or changed (a bind mount would experience the same problem). Elasticsearch then simply refuses to start.

This PR adds a setup script that manually runs the keystore migration in an independent container.

Does this close any currently open issues?
------------------------------------------
no

Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
no

Where has this been tested?
---------------------------
locally
