### PR TITLE
Upgrade to ELK v9!

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=elastic
-ELK_VERSION=8.17.0
+ELK_VERSION=9.2.3
 
 #----------- Images to use ----------------------#
 
@@ -9,6 +9,7 @@ LOGSTASH_IMAGE_NAME=elastdocker/logstash
 KIBANA_IMAGE_NAME=elastdocker/kibana
 APM_SERVER_IMAGE_NAME=elastdocker/apm-server
 FILEBEAT_IMAGE_NAME=docker.elastic.co/beats/filebeat
+METRICBEAT_IMAGE_NAME=docker.elastic.co/beats/metricbeat
 
 # the following images will be used as is
 ELASTICSEARCH_EXPORTER_IMAGE=quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=elastic
-ELK_VERSION=8.10.2
+ELK_VERSION=8.17.0
 
 #----------- Images to use ----------------------#
 
@@ -11,7 +11,7 @@ APM_SERVER_IMAGE_NAME=elastdocker/apm-server
 FILEBEAT_IMAGE_NAME=docker.elastic.co/beats/filebeat
 
 # the following images will be used as is
-ELASTICSEARCH_EXPORTER_IMAGE=justwatch/elasticsearch_exporter:1.1.0
+ELASTICSEARCH_EXPORTER_IMAGE=quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
 LOGSTASH_EXPORTER_IMAGE=alxrem/prometheus-logstash-exporter
 
 #----------- Resources --------------------------#

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ images:			## Show all Images of ELK and all its extra components.
 
 prune:			## Remove ELK Containers and Delete ELK-related Volume Data (the elastic_elasticsearch-data volume)
 	@make stop && make rm
-	@docker volume prune -f --filter label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}
+	@docker volume ls --filter label=com.docker.compose.project=${COMPOSE_PROJECT_NAME} --format "{{.Name}}" | xargs docker volume rm 2>/dev/null || true
+	@echo "Removed all volumes for project: ${COMPOSE_PROJECT_NAME}"
 
 help:       	## Show this help.
 	@echo "Make Application Docker Images and Containers using Docker Compose (v2) files."

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,5 @@ prune:			## Remove ELK Containers and Delete ELK-related Volume Data (the elasti
 	@docker volume prune -f --filter label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}
 
 help:       	## Show this help.
-	@echo "Make Application Docker Images and Containers using Docker-Compose files in 'docker' Dir."
+	@echo "Make Application Docker Images and Containers using Docker Compose (v2) files."
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m (default: help)\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,12 @@ COMPOSE_LOGGING := -f docker-compose.yml -f docker-compose.logs.yml
 COMPOSE_NODES := -f docker-compose.yml -f docker-compose.nodes.yml
 ELK_SERVICES   := elasticsearch logstash kibana apm-server
 ELK_LOG_COLLECTION := filebeat
-ELK_MONITORING := elasticsearch-exporter logstash-exporter filebeat-cluster-logs
+ELK_MONITORING := elasticsearch-exporter logstash-exporter filebeat-cluster-logs metricbeat
 ELK_NODES := elasticsearch-1 elasticsearch-2
 ELK_MAIN_SERVICES := ${ELK_SERVICES} ${ELK_MONITORING}
 ELK_ALL_SERVICES := ${ELK_MAIN_SERVICES} ${ELK_NODES} ${ELK_LOG_COLLECTION}
 
-compose_v2_not_supported = $(shell command docker compose 2> /dev/null)
-ifeq (,$(compose_v2_not_supported))
-  DOCKER_COMPOSE_COMMAND = docker-compose
-else
-  DOCKER_COMPOSE_COMMAND = docker compose
-endif
+DOCKER_COMPOSE_COMMAND = docker compose
 
 # --------------------------
 .PHONY: setup keystore certs all elk monitoring build down stop restart rm logs

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Stack Version: [9.2.3](https://www.elastic.co/guide/en/elasticsearch/reference/9
   - Anomaly Detection
   - SIEM (Security information and event management).
   - Enabling Trial License
-- Use Docker-Compose and `.env` to configure your entire stack parameters.
+- Use Docker Compose and `.env` to configure your entire stack parameters.
 - Persist Elasticsearch's Keystore and SSL Certifications.
 - Self-Monitoring Metrics Enabled (using Metricbeat for ES 9+).
 - Prometheus Exporters for Stack Metrics.
@@ -79,7 +79,7 @@ Elastdocker differs from `deviantony/docker-elk` in the following points.
 
 - Parameterize all other Config like Heap Size.
 
-- Add recommended environment configurations as Ulimits and Swap disable to the docker-compose.
+- Add recommended environment configurations as Ulimits and Swap disable to Docker Compose.
 
 - Make it ready to be extended into a multinode cluster.
 
@@ -108,8 +108,7 @@ Filebeat automatically discovers containers, parses logs, and ships them to Elas
 
 # Requirements
 
-- [Docker 20.05 or higher](https://docs.docker.com/install/)
-- [Docker-Compose 1.29 or higher](https://docs.docker.com/compose/install/)
+- [Docker 20.05 or higher](https://docs.docker.com/install/) with Docker Compose v2
 - 4GB RAM (For Windows and MacOS make sure Docker's VM has more than 4GB+ memory.)
 
 # Setup
@@ -125,7 +124,7 @@ Filebeat automatically discovers containers, parses logs, and ships them to Elas
     > **For Linux's docker hosts only**. By default virtual memory [is not enough](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html) so run the next command as root `sysctl -w vm.max_map_count=262144`
 3. Start Elastic Stack
     ```bash
-    $ make elk           <OR>         $ docker-compose up -d		<OR>		$ docker compose up -d
+    $ make elk           <OR>         $ docker compose up -d
     ```
 4. Visit Kibana at [https://localhost:5601](https://localhost:5601) or `https://<your_public_ip>:5601`
 
@@ -206,7 +205,7 @@ make keystore
 
 - Adding Two Extra Nodes to the cluster will make the cluster depending on them and won't start without them again.
 
-- Makefile is a wrapper around `Docker-Compose` commands, use `make help` to know every command.
+- Makefile is a wrapper around `Docker Compose` commands, use `make help` to know every command.
 
 - Elasticsearch will save its data to a volume named `elasticsearch-data`
 

--- a/apm-server/config/apm-server.yml
+++ b/apm-server/config/apm-server.yml
@@ -59,43 +59,8 @@ output.elasticsearch:
   # Client Certificate Key
   ssl.key: "/certs/apm-server.key"
 
-#============================= X-pack Monitoring =============================
+#============================= Monitoring =============================
 
-# APM server can export internal metrics to a central Elasticsearch monitoring
-# cluster.  This requires x-pack monitoring to be enabled in Elasticsearch.  The
-# reporting is disabled by default.
-
-# Set to true to enable the monitoring reporter.
-monitoring.enabled: true
-
-# Most settings from the Elasticsearch output are accepted here as well.
-# Note that these settings should be configured to point to your Elasticsearch *monitoring* cluster.
-# Any setting that is not set is automatically inherited from the Elasticsearch
-# output configuration. This means that if you have the Elasticsearch output configured,
-# you can simply uncomment the following line.
-monitoring.elasticsearch:
-
-  # Protocol - either `http` (default) or `https`.
-  protocol: "https"
-
-  # Authentication credentials
-  username: '${ELASTIC_USERNAME}'
-  password: '${ELASTIC_PASSWORD}'
-
-  # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
-  # In case you specify and additional path, the scheme is required: `http://elasticsearch:9200/path`.
-  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
-  hosts: '${ELASTICSEARCH_HOST_PORT}'
-
-  # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
-  ssl.enabled: true
-
-  # List of root certificates for HTTPS server verifications.
-  ssl.certificate_authorities: ["/certs/ca.crt"]
-
-  # Certificate for SSL client authentication.
-  ssl.certificate: "/certs/apm-server.crt"
-
-  # Client Certificate Key
-  ssl.key: "/certs/apm-server.key"
+# ES 9: xpack.monitoring is deprecated
+# Stack Monitoring is now handled by Metricbeat (see docker-compose.monitor.yml)
+monitoring.enabled: false

--- a/docker-compose.logs.yml
+++ b/docker-compose.logs.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 # will contain all elasticsearch data.
 volumes:
   filebeat-data:

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -1,16 +1,15 @@
-version: '3.5'
-
 services:
 
   # Prometheus Exporters ------------------------------
   elasticsearch-exporter:
     image: ${ELASTICSEARCH_EXPORTER_IMAGE}
     restart: always
-    command: ["--es.uri", "https://${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}@${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}",
-              "--es.ssl-skip-verify",
-              "--es.all",
-              "--es.snapshots",
-              "--es.indices"]
+    command:
+      - "--es.uri=https://${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}@${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+      - "--es.ssl-skip-verify"
+      - "--collector.clustersettings"
+      - "--collector.snapshots"
+      - "--collector.indices"
     ports:
       - "9114:9114"
 

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -1,5 +1,32 @@
 services:
 
+  # Stack Monitoring (ES 9 recommended) ------------------
+  metricbeat:
+    image: ${METRICBEAT_IMAGE_NAME}:${ELK_VERSION}
+    restart: always
+    user: root
+    command: -e --strict.perms=false
+    environment:
+      ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST}
+      ELASTICSEARCH_PORT: ${ELASTICSEARCH_PORT}
+      KIBANA_HOST: ${KIBANA_HOST}
+      KIBANA_PORT: ${KIBANA_PORT}
+      LOGSTASH_HOST: ${LOGSTASH_HOST}
+      APMSERVER_HOST: ${APMSERVER_HOST}
+      APMSERVER_PORT: ${APMSERVER_PORT}
+      ELASTIC_USERNAME: ${ELASTIC_USERNAME}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
+    volumes:
+      - ./metricbeat/config/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro
+      - ./secrets/certs/ca/ca.crt:/certs/ca.crt:ro
+    depends_on:
+      - elasticsearch
+    healthcheck:
+      test: ["CMD", "metricbeat", "test", "config"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   # Prometheus Exporters ------------------------------
   elasticsearch-exporter:
     image: ${ELASTICSEARCH_EXPORTER_IMAGE}
@@ -7,9 +34,10 @@ services:
     command:
       - "--es.uri=https://${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}@${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
       - "--es.ssl-skip-verify"
+      # Exporter v1.10.0+: collector.indices renamed to es.indices
+      - "--es.indices"
       - "--collector.clustersettings"
       - "--collector.snapshots"
-      - "--collector.indices"
     ports:
       - "9114:9114"
 

--- a/docker-compose.nodes.yml
+++ b/docker-compose.nodes.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 # will contain all elasticsearch data.
 volumes:
   elasticsearch-data-1:

--- a/docker-compose.setup.yml
+++ b/docker-compose.setup.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   keystore:
     image: ${ELASTICSEARCH_IMAGE_NAME}:${ELK_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 # To Join any other app setup using another network, change name and set external = true
 networks:
   default:

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -32,4 +32,5 @@ xpack.security.http.ssl.certificate_authorities: certs/ca.crt
 xpack.security.http.ssl.client_authentication: optional
 
 # Monitoring
-xpack.monitoring.collection.enabled: true
+# Note: xpack.monitoring.collection.enabled is deprecated in ES 9
+# Stack Monitoring is now handled by Metricbeat (see docker-compose.monitor.yml)

--- a/filebeat/filebeat.docker.logs.yml
+++ b/filebeat/filebeat.docker.logs.yml
@@ -1,6 +1,6 @@
 #================================== Description ========================================
-# Filebeat Config to send Elasticsearch/Logstash/Kibana in a docker host to Elasticsea-
-# sh cluster.
+# Filebeat Config to send Docker container logs to Logstash/Elasticsearch cluster.
+# Uses modern filestream input (ES 9+ recommended approach)
 
 name: filebeat-docker-logs-shipper
 
@@ -10,8 +10,7 @@ filebeat.config:
     reload.enabled: false
 
 #================================ Autodiscover =======================================
-# Autodiscover all containers with elasticsearch images, and add an separate input for
-# each container and log type.
+# Autodiscover all containers and collect logs using filestream input
 filebeat.autodiscover:
   providers:
     - type: docker
@@ -25,12 +24,22 @@ filebeat.autodiscover:
              - not.contains:
                 docker.container.image: kibana
           config:
-            - type: container
+            # ES 9+: Using filestream input (replaces deprecated container input)
+            - type: filestream
+              id: docker-${data.docker.container.id}
               paths:
                 - /var/lib/docker/containers/${data.docker.container.id}/*.log
+              parsers:
+                - container:
+                    stream: all
+                    format: auto
+              prospector:
+                scanner:
+                  symlinks: true
 
 processors:
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 # Output to Logstash
 output.logstash:
@@ -48,26 +57,16 @@ setup:
 
 #==================================== Monitoring =====================================
 # Enable Monitoring Beats
-# Filebeat can export internal metrics to a central Elasticsearch monitoring
-# cluster.  This requires xpack monitoring to be enabled in Elasticsearch
+# Filebeat can export internal metrics to a central Elasticsearch monitoring cluster.
 
-# Use deprecated option to avoid current UX bug in 7.3.0 where filebeat creates a
-# standalone monitoring cluster in the monitoring UI.
-# see: https://github.com/elastic/beats/pull/13182
-xpack.monitoring:
+monitoring:
   enabled: true
   elasticsearch:
     hosts: '${ELASTICSEARCH_HOST_PORT}'
     username: '${ELASTIC_USERNAME}'
     password: '${ELASTIC_PASSWORD}'
-
-
-#monitoring:
-#  enabled: true
-#  elasticsearch:
-#    hosts: '${ELASTICSEARCH_HOST_PORT}'
-#    username: '${ELASTIC_USERNAME}'
-#    password: '${ELASTIC_PASSWORD}'
+    ssl:
+      verification_mode: "none"
 
 #================================ HTTP Endpoint ======================================
 # Enabled so we can monitor filebeat using filebeat exporter if needed.

--- a/filebeat/filebeat.monitoring.yml
+++ b/filebeat/filebeat.monitoring.yml
@@ -1,6 +1,6 @@
 #================================== Description ========================================
-# Filebeat Config to send Elasticsearch/Logstash/Kibana in a docker host to Elasticsea-
-# sh cluster.
+# Filebeat Config to send Elasticsearch/Logstash/Kibana logs to Elasticsearch cluster.
+# Uses modern filestream input with container parser (ES 9+ recommended approach)
 
 name: filebeat-elk-monitoring
 
@@ -10,10 +10,10 @@ filebeat.config:
     reload.enabled: false
 
 #================================ Autodiscover =======================================
-# Autodiscover all containers with elasticsearch images, and add an separate input for
-# each container and log type.
+# Autodiscover containers and collect logs using filestream with modules
 filebeat.autodiscover:
   providers:
+    # Elasticsearch containers
     - type: docker
       templates:
         - condition:
@@ -22,25 +22,72 @@ filebeat.autodiscover:
           config:
             - module: elasticsearch
               server:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: elasticsearch-server-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
               gc:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: elasticsearch-gc-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
               audit:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: elasticsearch-audit-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
               slowlog:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: elasticsearch-slowlog-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
               deprecation:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: elasticsearch-deprecation-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
+
+    # Kibana containers
     - type: docker
       templates:
         - condition:
@@ -49,9 +96,20 @@ filebeat.autodiscover:
           config:
             - module: kibana
               log:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: kibana-log-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
+
+    # Logstash containers
     - type: docker
       templates:
         - condition:
@@ -60,17 +118,35 @@ filebeat.autodiscover:
           config:
             - module: logstash
               log:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: logstash-log-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
               slowlog:
+                enabled: true
                 input:
-                  type: container
+                  type: filestream
+                  id: logstash-slowlog-${data.docker.container.id}
                   paths: '/var/lib/docker/containers/${data.docker.container.id}/*.log'
-
+                  parsers:
+                    - container:
+                        stream: all
+                        format: auto
+                  prospector:
+                    scanner:
+                      symlinks: true
 
 processors:
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 # Output to ES directly.
 output.elasticsearch:
@@ -79,7 +155,6 @@ output.elasticsearch:
   password: '${ELASTIC_PASSWORD}'
   ssl:
     verification_mode: "none"
-
 
 #=================================== Kibana ==========================================
 # Enable setting up Kibana
@@ -93,27 +168,15 @@ setup:
 
 #==================================== Monitoring =====================================
 # Enable Monitoring Beats
-# Filebeat can export internal metrics to a central Elasticsearch monitoring
-# cluster.  This requires xpack monitoring to be enabled in Elasticsearch
 
-# Use deprecated option to avoid current UX bug in 7.3.0 where filebeat creates a
-# standalone monitoring cluster in the monitoring UI.
-# see: https://github.com/elastic/beats/pull/13182
-xpack.monitoring:
+monitoring:
   enabled: true
-#  elasticsearch:
-#    hosts: '${ELASTICSEARCH_HOST_PORT}'
-#    username: '${ELASTIC_USERNAME}'
-#    password: '${ELASTIC_PASSWORD}'
-
-#monitoring:
-#  enabled: true
-#  elasticsearch:
-#    hosts: '${ELASTICSEARCH_HOST_PORT}'
-#    username: '${ELASTIC_USERNAME}'
-#    password: '${ELASTIC_PASSWORD}'
-#    ssl.enabled: true
-#    ssl.verification_mode: none
+  elasticsearch:
+    hosts: '${ELASTICSEARCH_HOST_PORT}'
+    username: '${ELASTIC_USERNAME}'
+    password: '${ELASTIC_PASSWORD}'
+    ssl:
+      verification_mode: "none"
 
 #================================ HTTP Endpoint ======================================
 # Enabled so we can monitor filebeat using filebeat exporter if needed.

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -1,9 +1,7 @@
 ---
-http.host: "0.0.0.0"
+# Logstash 9: API settings use 'api.http.*' namespace
+api.http.host: "0.0.0.0"
 
-## X-Pack security credentials
-xpack.monitoring.elasticsearch.hosts: ${ELASTICSEARCH_HOST_PORT}
-xpack.monitoring.enabled: true
-xpack.monitoring.elasticsearch.username: ${ELASTIC_USERNAME}
-xpack.monitoring.elasticsearch.password: ${ELASTIC_PASSWORD}
-xpack.monitoring.elasticsearch.ssl.certificate_authority: /certs/ca.crt
+# ES 9: xpack.monitoring is deprecated
+# Stack Monitoring is now handled by Metricbeat (see docker-compose.monitor.yml)
+monitoring.enabled: false

--- a/logstash/pipeline/main.conf
+++ b/logstash/pipeline/main.conf
@@ -13,8 +13,11 @@ output {
         hosts => "${ELASTICSEARCH_HOST_PORT}"
         user => "${ELASTIC_USERNAME}"
         password => "${ELASTIC_PASSWORD}"
-        ssl => true
-        ssl_certificate_verification => false
-        cacert => "/certs/ca.crt"
+        # Logstash 9: ssl renamed to ssl_enabled
+        ssl_enabled => true
+        # Logstash 9: ssl_certificate_verification replaced with ssl_verification_mode
+        ssl_verification_mode => "none"
+        # Logstash 9: cacert replaced with ssl_certificate_authorities
+        ssl_certificate_authorities => "/certs/ca.crt"
     }
 }

--- a/metricbeat/config/metricbeat.yml
+++ b/metricbeat/config/metricbeat.yml
@@ -1,0 +1,63 @@
+#================================== Description ========================================
+# Metricbeat config for Stack Monitoring in ES 9
+# Replaces deprecated xpack.monitoring.collection.enabled
+
+name: metricbeat-stack-monitoring
+
+#================================ Modules ===============================================
+
+metricbeat.modules:
+
+#------------------------------- Elasticsearch Module ----------------------------------
+- module: elasticsearch
+  xpack.enabled: true
+  period: 10s
+  hosts: ["https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"]
+  username: "${ELASTIC_USERNAME}"
+  password: "${ELASTIC_PASSWORD}"
+  ssl.enabled: true
+  ssl.certificate_authorities: ["/certs/ca.crt"]
+  ssl.verification_mode: certificate
+  # Collect cluster-wide metrics including all nodes
+  scope: cluster
+
+#------------------------------- Kibana Module -----------------------------------------
+- module: kibana
+  xpack.enabled: true
+  period: 10s
+  hosts: ["https://${KIBANA_HOST}:${KIBANA_PORT}"]
+  username: "${ELASTIC_USERNAME}"
+  password: "${ELASTIC_PASSWORD}"
+  ssl.enabled: true
+  ssl.certificate_authorities: ["/certs/ca.crt"]
+  ssl.verification_mode: certificate
+
+#------------------------------- Logstash Module ---------------------------------------
+- module: logstash
+  xpack.enabled: true
+  period: 10s
+  hosts: ["${LOGSTASH_HOST}:9600"]
+
+#------------------------------- Beat Module (APM Server) ------------------------------
+- module: beat
+  xpack.enabled: true
+  period: 10s
+  hosts: ["https://${APMSERVER_HOST}:${APMSERVER_PORT}"]
+  ssl.enabled: true
+  ssl.certificate_authorities: ["/certs/ca.crt"]
+  ssl.verification_mode: certificate
+
+#================================ Outputs ==============================================
+
+output.elasticsearch:
+  hosts: ["https://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"]
+  username: "${ELASTIC_USERNAME}"
+  password: "${ELASTIC_PASSWORD}"
+  ssl.enabled: true
+  ssl.certificate_authorities: ["/certs/ca.crt"]
+  ssl.verification_mode: certificate
+
+#================================ Logging ==============================================
+
+logging.level: info
+logging.to_stderr: true

--- a/setup/setup-certs.sh
+++ b/setup/setup-certs.sh
@@ -20,7 +20,8 @@ mkdir -p $OUTPUT_DIR/ca
 
 
 printf "Generating CA Certificates... \n"
-PASSWORD=`openssl rand -base64 32`
+# ES 9: Generate random password without openssl (not available in ES 9 container)
+PASSWORD=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32`
 /usr/share/elasticsearch/bin/elasticsearch-certutil ca --pass "$PASSWORD" --pem --out $ZIP_CA_FILE &> /dev/null
 printf "Generating Certificates... \n"
 unzip -qq $ZIP_CA_FILE -d $OUTPUT_DIR;


### PR DESCRIPTION
## Upgrade to ELK v9!

This PR upgrades ElastDocker from Elasticsearch 8.17.0 to the latest stable version **9.2.3**, implementing all necessary breaking changes in the process.

### 🎯 What's Changed

**Versions**
- Upgraded from `8.17.0` to `9.2.3` (latest stable release)
- All components synchronized: Elasticsearch, Kibana, Logstash, APM Server, Filebeat
- Drop support for docker-compose v1, it's all `docker compose` now.

**Stack Monitoring**
- Migrated from deprecated internal `xpack.monitoring` to **Metricbeat-based collection**
- Follows Elastic's recommended ES 9+ architecture

**Filebeat Log Collection**
- Migrated from deprecated `container` input to modern **`filestream` input**
- Eliminates all deprecation warnings
- Uses built-in container parser for Docker logs

**Configuration Updates**
- All deprecated settings removed or updated
- Logstash, APM Server, and Elasticsearch configs modernized
- Certificate generation compatible with ES 9 containers
- Prometheus exporters updated for latest exporter versions

---

This is partially AI Generated but human validated and tested. 🫡