### PR TITLE
Bump mise-action to v4 for Node 24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           install_args: "--locked" # honor mise.lock


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Bump `jdx/mise-action` from v2.4.4 to v4.2.0 so the lint workflow runs on Node 24 and clears the GitHub Actions Node 20 deprecation warning.

**Changes** <!-- pr:changes -->

- **Fixed**: pin `jdx/mise-action` to `e6a8b397…` (v4.2.0, `runs.using: node24`)

> [!NOTE]
> CodeQL default setup was left alone. GET shows `not-configured`; PUT `/code-scanning/default-setup` returned 404, so enabling via API was not cheap/viable here.

---

<details><summary>Tests & Validation</summary>

Pin matches `jdx/mise-action@v4.2.0` commit SHA; action.yml declares `runs.using: node24`. Existing lint inputs (`install`, `install_args`, `cache`, `experimental`) remain supported. Pre-commit (yamllint, actionlint, zizmor, pinact) passed on the workflow change.

</details>

### Relevant Links

<!-- pr:links -->

- [mise-action v4.0.0 (Node.js 24 Runtime)](https://github.com/jdx/mise-action/releases/tag/v4.0.0)
- [mise-action v4.2.0](https://github.com/jdx/mise-action/releases/tag/v4.2.0)

---

_<sub>🤝 Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby, with their input/approval.</sub>_